### PR TITLE
Fixed: when saving changes and navigating to draft order page changes were not reflecting (#2nvwjyb)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -145,9 +145,9 @@ export default defineComponent({
       }
       this.store.dispatch('order/updateLineItems', this.order);
     },
-    updateDraftOrder () {
+    async updateDraftOrder () {
       const shopConfig = JSON.parse(process.env.VUE_APP_SHOPIFY_SHOP_CONFIG);
-      this.store.dispatch('order/updateDraftOrder', this.order);
+      await this.store.dispatch('order/updateDraftOrder', this.order);
       const app = createApp({
           apiKey: shopConfig[this.routeParams.shop].apiKey,
           host: this.routeParams.host


### PR DESCRIPTION
Updating draft order action takes place asynchronously and user is navigated to the draft order page without waiting for the action to complete. Used async/await to execute the code to navigate user to draft order page after the update action is complete