### PR TITLE
Implemented: support to allow single pickup location for all order items(#86cx1fun1)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -22,6 +22,9 @@ const actions: ActionTree<OrderState, RootState> = {
         if(isBopisOrder) {
           order.selectedFacility = order.line_items[0].properties.find((property: any) => property.name == 'Store Pickup').value
           order.selectedFacilityId = order.line_items[0].properties.find((property: any) => property.name == '_pickupstore').value
+        } else {
+          order.selectedFacility = ""
+          order.selectedFacilityId = ""
         }
         commit(types.DRAFT_ORDER_UPDATED, order);
       } else {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -7,7 +7,7 @@
       </ion-toolbar>
     </ion-header>
     <ion-content>
-      <div>
+      <div v-if="order?.name || Object.keys(order)?.length">
         <h1 class="center-align">{{ $t("Order") }} {{ order.name }}</h1>
         <ion-card>
           <ion-list>
@@ -24,47 +24,34 @@
             </ion-item>
           </ion-list>
         </ion-card>
-    
-        <main v-for="item in order.line_items" :key="item.id">
-          <ion-card>
-            <ion-item lines="none">
-              <ion-label>
-                <h2>{{ item.title }}</h2>
-                <p>{{ item.variant_title }}</p>
-                <p class="ion-text-wrap">{{ $t("SKU") }}: {{ item.sku }}</p>
-              </ion-label>
-              <ion-button :disabled="JSON.stringify(order) == JSON.stringify(initialOrder)" fill="clear" color="medium" slot="end" @click="undo(item)">
-                <ion-icon slot="icon-only" :icon="arrowUndoOutline" />
-              </ion-button>            
-            </ion-item>
-            <ion-item>
-              <ion-label>{{ $t('Delivery method') }}</ion-label>
-              <ion-select interface="popover" :value="item.deliveryMethodTypeId" @ionChange="updateDeliveryMethod($event, item)">
-                <ion-select-option v-for="method in deliveryMethods" :key="method.value" :value="method.value">{{ method.name }}</ion-select-option>
-              </ion-select>
-            </ion-item>
-            <ion-radio-group v-if="item.deliveryMethodTypeId !== 'STOREPICKUP'" :value="checkPreorderBackorderItem(item)" @ionChange="markPreorderBackorderItem(item, $event)">
-              <ion-item class="border-top">
-                <ion-radio :disabled="isPreorderOrBackorderProduct(item, 'PRE-ORDER')" slot="start" value="Pre Order" />
-                <ion-label>{{ $t("Pre Order") }}</ion-label>
-                <ion-note slot="end" :color="getEstimatedDeliveryDate(item, 'PRE-ORDER') ? '' : 'warning'">{{ getEstimatedDeliveryDate(item, "PRE-ORDER") ? getEstimatedDeliveryDate(item, "PRE-ORDER") : $t("No shipping estimates") }}</ion-note>
-              </ion-item>
-              <ion-item class="border-top">
-                <ion-radio :disabled="isPreorderOrBackorderProduct(item, 'BACKORDER')" slot="start" value="Back Order" />
-                <ion-label >{{ $t("Back Order") }}</ion-label>
-                <ion-note slot="end" :color="getEstimatedDeliveryDate(item, 'BACKORDER') ? '' : 'warning'">{{ getEstimatedDeliveryDate(item, "BACKORDER") ? getEstimatedDeliveryDate(item, "BACKORDER") : $t("No shipping estimates") }}</ion-note>
-              </ion-item>
-            </ion-radio-group>
-            <ion-button v-else-if="item.deliveryMethodTypeId === 'STOREPICKUP' && !item.selectedFacility" @click="updatePickupLocation(item)" expand="block" fill="outline">{{ $t("Select pickup location")}}</ion-button>
-            <ion-item v-else>
-              <ion-label class="ion-text-wrap">{{ item.selectedFacility }}</ion-label>
-              <ion-button slot="end" @click="updatePickupLocation(item)" color="medium" fill="outline">{{ $t("Change Store")}}</ion-button>
-            </ion-item>
-          </ion-card>
-        </main>
+        <ion-card>
+          <ion-item v-for="(item, index) in order.line_items" :key="item.id" :lines="order.line_items.length - 1 === index ? 'full' : 'none'">
+            <ion-label>
+              <h2>{{ item.title }}</h2>
+              <p>{{ item.variant_title }}</p>
+              <p class="ion-text-wrap">{{ $t("SKU") }}: {{ item.sku }}</p>
+            </ion-label>
+          </ion-item>
+          <ion-item v-if="selectedFacility" lines="none">
+            <ion-label class="ion-text-wrap">{{ selectedFacility }}</ion-label>
+            <ion-button slot="end" @click="removeFacility()" color="danger" fill="clear">
+              <ion-icon slot="icon-only" :icon="removeCircleOutline" />
+            </ion-button>
+          </ion-item>
+          <ion-button v-else-if="order.line_items?.length" class="ion-margin" expand="block" fill="outline" @click="updatePickupLocation">{{ $t("Select pickup location")}}</ion-button>
+        </ion-card>
+
         <div class="text-center center-align">
           <ion-button :disabled="!isChanged()" @click="save()">{{ $t("Save changes to order") }}</ion-button>
         </div>
+      </div>
+
+      <div v-else class="text-center center-align">
+        <p>{{ $t("Order not found") }}</p>
+      </div>
+
+      <div class="text-center center-align">
+        <ion-button color="danger" fill="outline" @click="back($event)">{{ $t("Exit") }}</ion-button>
       </div>
     </ion-content>
   </ion-page>
@@ -83,15 +70,11 @@ import {
   IonList,
   IonNote,
   IonPage,
-  IonSelect,
-  IonSelectOption,
   IonTitle,
   IonToolbar,
-  IonRadio,
-  IonRadioGroup,
   modalController
 } from "@ionic/vue";
-import { arrowUndoOutline } from "ionicons/icons";
+import { removeCircleOutline } from "ionicons/icons";
 import { defineComponent } from 'vue';
 import { mapGetters, useStore } from 'vuex';
 import { useRouter } from 'vue-router';
@@ -99,8 +82,6 @@ import { DateTime } from 'luxon';
 import { Redirect } from "@shopify/app-bridge/actions";
 import createApp from "@shopify/app-bridge";
 import PickupLocationModal from "./PickupLocationModal.vue";
-import { translate } from "@/i18n";
-import { showToast } from "@/utils";
 
 export default defineComponent({
   name: 'OrderDetail',
@@ -110,39 +91,26 @@ export default defineComponent({
     IonCard,
     IonContent,
     IonHeader,
-    IonItem,
     IonIcon,
+    IonItem,
     IonLabel,
     IonList,
     IonNote,
     IonPage,
-    IonSelect,
-    IonSelectOption,
     IonTitle,
-    IonToolbar,
-    IonRadio,
-    IonRadioGroup
+    IonToolbar
   },
   data() {
     return {
       initialOrder: {} as any,
-      deliveryMethods: [
-        {
-          name: 'Store pickup',
-          value: 'STOREPICKUP'
-        },
-        {
-          name: 'Shipping',
-          value: 'STANDARD'
-        }
-      ]
+      selectedFacility: "",
+      selectedFacilityId: ""
     }
   },
   computed: {
     ...mapGetters({
       order: 'order/getDraftOrder',
       shopifyStores: 'shop/getStores',
-      getPreorderItemAvailability: 'stock/getPreorderItemAvailability',
       routeParams: 'shop/getRouteParams'
     })
   },
@@ -152,32 +120,16 @@ export default defineComponent({
       await this.store.dispatch('order/getDraftOrder', this.$route.query.id);
     }
     this.initialOrder = JSON.parse(JSON.stringify(this.order));
+    this.selectedFacility = this.initialOrder?.selectedFacility
+    this.selectedFacilityId = this.initialOrder?.selectedFacilityId
   },
   methods: {
     back(event: any) {
       event?.preventDefault();
       history.back()
     },
-    isPreorderOrBackorderProduct(item: any, label: string){
-      const product = this.getPreorderItemAvailability(item.sku);  
-      return !(product.label === label);
-    },
-    updateDeliveryMethod(event: any, item: any) {
-      item.deliveryMethodTypeId = event.detail.value;
-      if (item.deliveryMethodTypeId !== 'STOREPICKUP') item.properties = item.properties.filter((property: any) => !(property.name === '_pickupstore' || property.name === 'Store Pickup' || property.name === 'Pickup Store'))
-      this.store.dispatch('order/updateLineItems', this.order)
-    },
-    markPreorderBackorderItem (item: any, event: any) {
-      const product = this.getPreorderItemAvailability(item.sku)
-      item.properties.push({ name: 'Note', value: event.detail.value });
-      if(product.estimatedDeliveryDate){
-        item.properties.push({ name: 'PROMISE_DATE', value: DateTime.fromISO(product.estimatedDeliveryDate).toFormat("MM/dd/yyyy") })
-      }
-      this.store.dispatch('order/updateLineItems', this.order);
-    },
     async updateDraftOrder () {
       const shopConfig = JSON.parse(process.env.VUE_APP_SHOPIFY_SHOP_CONFIG);
-      this.order.line_items.map((lineItem: any) => delete lineItem.deliveryMethodTypeId)
       await this.store.dispatch('order/updateDraftOrder', this.order).then(() => {
         const app = createApp({
           apiKey: shopConfig[this.routeParams.shop].apiKey,
@@ -186,53 +138,39 @@ export default defineComponent({
         Redirect.create(app).dispatch(Redirect.Action.ADMIN_PATH, `/draft_orders/${this.routeParams.id}`);
       })
     },
-    checkPreorderBackorderItem (item: any) {
-      const property = item.properties?.find((property: any) => property.name === 'Note')?.value;
-      return property ? property : "" ;
-    },
     timeFromNow (time: string) {
       if (time) {
         const timeDiff = DateTime.fromISO(time).diff(DateTime.local());
         return DateTime.local().plus(timeDiff).toRelative();
       }
     },
-    getEstimatedDeliveryDate(item: any, label: string){
-      const labelMapping = {
-        "BACKORDER": "Back Order",
-        "PRE-ORDER": "Pre Order",
-      } as any
-      if(this.checkPreorderBackorderItem(item) === labelMapping[label]) {
-        return item.properties.find((property: any) => property.name === "PROMISE_DATE") ? item.properties.find((property: any) => property.name === "PROMISE_DATE").value : "";
-      }
-      const product = this.getPreorderItemAvailability(item.sku);
-      if(product.label === label){
-        return DateTime.fromISO(product.estimatedDeliveryDate).toFormat("MM/dd/yyyy");
-      }
-    },
-    async updatePickupLocation(item: any) {
+    async updatePickupLocation() {
       const modal = await modalController
         .create({
           component: PickupLocationModal,
           // Adding backdropDismiss as false because on dismissing the modal through backdrop,
           // backrop.role returns 'backdrop' giving unexpected result
           backdropDismiss: false,
-          componentProps: { item, facilityId: item.properties.find((property: any) => property.name == '_pickupstore')?.value }
+          componentProps: { facilityId: this.selectedFacilityId }
         })
       modal.onDidDismiss().then((result) => {
         if (result.role) {
           // role will have the passed data
           const facilityData = result.role as any
-          item.selectedFacility = facilityData.selectedFacility
+          this.selectedFacility = facilityData.selectedFacility
+          this.selectedFacilityId = facilityData.storeCode
 
-          // Filtering item properties that are not related to pickup as we want to remove the previously associated properties and add the new one
-          // Using this approach, as if we will filter and update the pickup properties we will need multiple looping on the properties
-          const itemProperties = item.properties.filter((property: any) => property.name != "_pickupstore" && property.name != "Store Pickup")
+          this.order.line_items.map((lineItem: any) => {
+            // Filtering item properties that are not related to pickup as we want to remove the previously associated properties and add the new one
+            // Using this approach, as if we will filter and update the pickup properties we will need multiple looping on the properties
+            const itemProperties = lineItem.properties.filter((property: any) => property.name != "_pickupstore" && property.name != "Store Pickup")
 
-          // Adding the selected facility information as pickup facility
-          itemProperties.push({ name: '_pickupstore', value: facilityData.storeCode }, { name: 'Store Pickup', value: item.selectedFacility })
+            // Adding the selected facility information as pickup facility
+            itemProperties.push({ name: '_pickupstore', value: this.selectedFacilityId }, { name: 'Store Pickup', value: this.selectedFacility })
 
-          // Reassigning the item properties with updated properties array
-          item.properties = itemProperties
+            // Reassigning the item properties with updated properties array
+            lineItem.properties = itemProperties
+          })
 
           this.store.dispatch('order/updateLineItems', this.order);
         }
@@ -260,36 +198,13 @@ export default defineComponent({
     },
     isChanged() {
       if (Object.keys(this.order).length && Object.keys(this.initialOrder).length) {
-        return this.order.line_items.some((updatedItem: any, index: number) => {
-          const isMethodUpdated = updatedItem.deliveryMethodTypeId !== this.initialOrder.line_items[index].deliveryMethodTypeId
-          return updatedItem.deliveryMethodTypeId !== 'STOREPICKUP' ? isMethodUpdated : isMethodUpdated && updatedItem.selectedFacility;
-        })
+        return this.selectedFacility;
       }
+      return false;
     },
-    async undo(item: any) {
-      const header = this.$t('Clear edits')
-      const message = this.$t('Are you sure you want to undo the changes you’ve made to this order item?')
-
-      const alert = await alertController
-        .create({
-          header: header,
-          message: message,
-          buttons: [{
-            text: this.$t('Cancel'),
-            role: 'cancel'
-          },{
-            text: this.$t('Clear'),
-            handler: async () => {
-              // finding the initial line_item (without edits) and updating it in this.order
-              const initialItem = this.initialOrder.line_items.find((lineItem: any) => lineItem.id === item.id)
-              const index = this.order.line_items.findIndex((lineItem: any) => lineItem.id === item.id)
-              this.order.line_items.splice(index, 1, initialItem)
-              this.store.dispatch('order/updateLineItems', this.order)
-              showToast(translate('Previous edits cleared successfully'))
-            }
-          }]
-        });
-      return alert.present();
+    removeFacility() {
+      this.selectedFacility = ""
+      this.selectedFacilityId = ""
     }
   },
   setup() {
@@ -297,7 +212,7 @@ export default defineComponent({
     const router = useRouter();
 
     return {
-      arrowUndoOutline,
+      removeCircleOutline,
       router,
       store
     };

--- a/src/views/PickupLocationModal.vue
+++ b/src/views/PickupLocationModal.vue
@@ -149,7 +149,6 @@ export default defineComponent({
           this.nearbyStores.push({ ...storeData, isInventoryAvailableForAllProducts: false });
         }
       });
-      console.log('this.nearbyStores', this.nearbyStores)
     } catch(err) {
       console.error(err)
     } finally {
@@ -237,8 +236,6 @@ export default defineComponent({
 
           return inventoryByFacilities;
         }, {})
-
-        console.log('inventoryByFacilities', inventoryByFacilities);
 
         return inventoryByFacilities;
       } catch (error) {

--- a/src/views/PickupLocationModal.vue
+++ b/src/views/PickupLocationModal.vue
@@ -27,7 +27,7 @@
         <ion-label>{{ $t("Nearby stores") }}</ion-label>
       </ion-list-header>
       <ion-radio-group v-model="selectedFacility">
-        <ion-item v-for="store of nearbyStores" :key="store.facilityId">
+        <ion-item v-for="store of nearbyStores" :key="store.storeCode">
           <ion-radio :disabled="!store.isInventoryAvailableForAllProducts" :value="store" slot="start" />
           <ion-label>
             <h2>{{ store.facilityName || store.storeName }}</h2>
@@ -39,7 +39,7 @@
     </ion-list>
     <!-- Only show select button if there are stores to select from -->
     <div v-if="nearbyStores.length" class="ion-text-center">
-      <ion-button :disabled="Object.keys(selectedFacility).length == 0 || selectedFacility.facilityId == facilityId" @click="updateFacility()">{{ $t("Select pickup location") }}</ion-button>
+      <ion-button :disabled="Object.keys(selectedFacility).length == 0 || selectedFacility.storeCode == facilityId" @click="updateFacility()">{{ $t("Select pickup location") }}</ion-button>
     </div>
   </ion-content>
 </template>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed Shipping method selection support from the app, if the order was previously store pickup then removing the facility from the order will make it standard order.
- Added facility selection at order level and removed its support from item level
- Updated the UI as per the above flow


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:

![image](https://github.com/user-attachments/assets/2eb427c5-f4a5-43da-8923-d7b89f7db119)

![image](https://github.com/user-attachments/assets/b6c1279d-7b79-49cd-8fe5-b6ce5e12ffdf)


After:

![image](https://github.com/user-attachments/assets/f80ae6b9-a3ab-46e9-91cd-75197e45c4ac)


![image](https://github.com/user-attachments/assets/149d168e-0277-4608-a854-bef5a4c8cc7b)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/shopify-admin-helper/blob/main/CONTRIBUTING.md)